### PR TITLE
define method as public static to resolve notices on newer versions of PHP

### DIFF
--- a/includes/class.template.php
+++ b/includes/class.template.php
@@ -179,7 +179,7 @@ class PageLinesTemplate {
 	/**
 	 * Get current post type, set as GET on 'add new' pages
 	 */
-	function current_admin_post_type(){
+	public static function current_admin_post_type(){
 		global $pagenow;
 		global $post;
 


### PR DESCRIPTION
Reported quite a few times at https://forum.pagelines.com/search/?type=all&q=current_admin_post_type